### PR TITLE
Made localDate formatter more resilient. It was probably working fine…

### DIFF
--- a/TemplateProcessor/src/main/kotlin/org/liamjd/cantilever/lambda/TemplateProcessorHandler.kt
+++ b/TemplateProcessor/src/main/kotlin/org/liamjd/cantilever/lambda/TemplateProcessorHandler.kt
@@ -69,10 +69,7 @@ class TemplateProcessorHandler : RequestHandler<SQSEvent, String> {
                     is SqsMsgBody.PageModelMsg, is SqsMsgBody.MarkdownPostUploadMsg -> {
                         // do nothing, these messages are not valid in this context
                     }
-
                 }
-
-
             } catch (se: SerializationException) {
                 logger.error("Failed to deserialize eventRecord $eventRecord, exception: ${se.message}")
                 responses.add("500 Server Error")
@@ -199,7 +196,7 @@ class TemplateProcessorHandler : RequestHandler<SQSEvent, String> {
         model["date"] = postMsg.metadata.date
 
         val html = with(logger) {
-            val nav = navigationBuilder.getPostNavigationObjects(postMsg.metadata,sourceBucket)
+            val nav = navigationBuilder.getPostNavigationObjects(postMsg.metadata, sourceBucket)
             nav.entries.forEach {
                 model[it.key] = it.value
             }

--- a/TemplateProcessor/src/main/kotlin/org/liamjd/cantilever/lambda/handlebars/LocalDateFormatter.kt
+++ b/TemplateProcessor/src/main/kotlin/org/liamjd/cantilever/lambda/handlebars/LocalDateFormatter.kt
@@ -2,13 +2,15 @@ package org.liamjd.cantilever.lambda.handlebars
 
 import com.github.jknack.handlebars.Helper
 import com.github.jknack.handlebars.Options
-import kotlinx.datetime.LocalDate
-import kotlinx.datetime.toJavaLocalDate
+import kotlinx.datetime.*
 import org.liamjd.cantilever.common.now
 import java.time.format.DateTimeFormatter
 
 /**
- * Only handles LocalDate with no time component
+* A Handlebars helper to format a LocalDate or LocalDateTime object
+ * @param inputFormat the format of the input date, defaults to dd/MM/yyyy
+ * @return a formatted date string
+ * There are some predefined ISO formats, or you can supply your own
  */
 class LocalDateFormatter(private val inputFormat: String = "dd/MM/yyyy") : Helper<Any> {
 
@@ -17,38 +19,63 @@ class LocalDateFormatter(private val inputFormat: String = "dd/MM/yyyy") : Helpe
         private const val ISO_LOCAL_DATE = "ISO_LOCAL_DATE"
         private const val ISO_ORDINAL_DATE = "ISO_ORDINAL_DATE"
         private const val ISO_WEEK_DATE = "ISO_WEEK_DATE"
+        private const val ISO_LOCAL_DATE_TIME = "ISO_LOCAL_DATE_TIME"
     }
 
     override fun apply(value: Any?, options: Options): CharSequence {
 
         if (value != null) {
-            val outputFormatter = when (val format = options.param(0, options.hash<Any>("format", inputFormat)) as String) {
-                ISO_DATE -> {
-                    DateTimeFormatter.ISO_DATE
+            val dateTime: LocalDateTime = when (value) {
+                is LocalDate -> {
+                    value.atStartOfDayIn(TimeZone.currentSystemDefault())
+                        .toLocalDateTime(TimeZone.currentSystemDefault())
                 }
 
-                ISO_LOCAL_DATE -> {
-                    DateTimeFormatter.ISO_LOCAL_DATE
-                }
+                is LocalDateTime ->
+                    value
 
-                ISO_ORDINAL_DATE -> {
-                    DateTimeFormatter.ISO_ORDINAL_DATE
-                }
-
-                ISO_WEEK_DATE -> {
-                    DateTimeFormatter.ISO_WEEK_DATE
+                is Instant -> {
+                    value.toLocalDateTime(TimeZone.currentSystemDefault())
                 }
 
                 else -> {
-                    try {
-                        DateTimeFormatter.ofPattern(format)
-                    } catch (iae: IllegalArgumentException) {
-                        println("Could not parse localDate format string '$format'; reverting to ISO_LOCAL_DATE")
-                        DateTimeFormatter.ISO_LOCAL_DATE
-                    }
+                    println("Unable to convert value (${value::class}) to LocalDateTime; defaulting to now")
+                    Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
                 }
             }
-            return outputFormatter.format((value as LocalDate).toJavaLocalDate())
+
+            val outputFormatter =
+                when (val format = options.param(0, options.hash<Any>("format", inputFormat)) as String) {
+                    ISO_DATE -> {
+                        DateTimeFormatter.ISO_DATE
+                    }
+
+                    ISO_LOCAL_DATE -> {
+                        DateTimeFormatter.ISO_LOCAL_DATE
+                    }
+
+                    ISO_ORDINAL_DATE -> {
+                        DateTimeFormatter.ISO_ORDINAL_DATE
+                    }
+
+                    ISO_WEEK_DATE -> {
+                        DateTimeFormatter.ISO_WEEK_DATE
+                    }
+                    ISO_LOCAL_DATE_TIME -> {
+                        DateTimeFormatter.ISO_LOCAL_DATE_TIME
+                    }
+
+                    else -> {
+                        try {
+                            println("Custom format ($format) supplied")
+                            DateTimeFormatter.ofPattern(format)
+                        } catch (iae: IllegalArgumentException) {
+                            println("Could not parse localDate format string '$format'; reverting to ISO_LOCAL_DATE")
+                            DateTimeFormatter.ISO_LOCAL_DATE
+                        }
+                    }
+                }
+            return outputFormatter.format((dateTime).toJavaLocalDateTime())
         }
         return LocalDate.now().toString()
     }

--- a/TemplateProcessor/src/test/kotlin/org/liamjd/cantilever/lambda/HandlebarsRendererTest.kt
+++ b/TemplateProcessor/src/test/kotlin/org/liamjd/cantilever/lambda/HandlebarsRendererTest.kt
@@ -6,6 +6,8 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.Month
 import kotlin.test.*
 
 internal class HandlebarsRendererTest {
@@ -88,7 +90,7 @@ internal class HandlebarsRendererTest {
     }
 
     @Test
-    fun `localDate formatter works when custom format supplied`() {
+    fun `localDate formatter works when project format supplied`() {
         // setup
         val templateString = """{{ localDate this.date this.dateFormat }}"""
         val expectedResult = "24/09/2023"
@@ -101,6 +103,40 @@ internal class HandlebarsRendererTest {
             val result = renderer.render(model, templateString)
             // verify
             assertEquals(expectedResult, result)
+        }
+    }
+
+    @Test
+    fun `localDate formatter when custom format supplied`() {
+        // setup
+        val templateString = """{{ localDate this.date "HH:mm dd MMM yyyy" }}"""
+        val expectedResult = "20:14 21 Oct 2023"
+        val dateTime = LocalDateTime(year = 2023, month = Month.OCTOBER, dayOfMonth = 21, hour = 20, minute = 14)
+        val model = mapOf<String,Any?>("date" to dateTime)
+
+        with(mockLogger) {
+            val renderer = HandlebarsRenderer()
+            // execute
+            val result = renderer.render(model, templateString)
+            // verify
+            assertEquals(expectedResult,result)
+        }
+    }
+
+    @Test
+    fun `localDate formatter when ISO format supplied`() {
+        // setup
+        val templateString = """{{ localDate this.date "ISO_WEEK_DATE" }}"""
+        val expectedResult = "2023-W42-6"
+        val dateTime = LocalDateTime(year = 2023, month = Month.OCTOBER, dayOfMonth = 21, hour = 20, minute = 14)
+        val model = mapOf<String,Any?>("date" to dateTime)
+
+        with(mockLogger) {
+            val renderer = HandlebarsRenderer()
+            // execute
+            val result = renderer.render(model, templateString)
+            // verify
+            assertEquals(expectedResult,result)
         }
     }
 


### PR DESCRIPTION
… but now it's better, and it handles time as well as date now.
Closes #52 