### PR TITLE
Templates don't know if they are used by pages or posts. 

### DIFF
--- a/SharedModels/src/main/kotlin/org/liamjd/cantilever/services/impl/DynamoDBServiceImpl.kt
+++ b/SharedModels/src/main/kotlin/org/liamjd/cantilever/services/impl/DynamoDBServiceImpl.kt
@@ -617,7 +617,7 @@ class DynamoDBServiceImpl(
                 log("Found ${response.count()} nodes matching template '$templateKey' in domain: $projectDomain")
                 response.items().mapNotNull { it["srcKey"]?.s() }
             } else {
-                log("No nodes found matching template '$templateKey' in domain: $projectDomain")
+                log("No ${contentType.dbType}s nodes found matching template '$templateKey' in domain: $projectDomain")
                 emptyList()
             }
         }


### PR DESCRIPTION
Don't short-circuit regeneration based on template.